### PR TITLE
Encoding file type in mode

### DIFF
--- a/src/AzureBlobFS.js
+++ b/src/AzureBlobFS.js
@@ -12,6 +12,8 @@ const path = require('path');
 const readAll = require('./util/readAll');
 const sleep = require('./util/sleep');
 const { R_OK, W_OK, X_OK } = require('fs');
+const S_IFREG = 32768;
+const S_IFDIR = 16384;
 const { promisifyObject, toCallback } = require('./util/promisifyHelper');
 
 const
@@ -452,7 +454,7 @@ class AzureBlobFS {
           contentSettings: properties.contentSettings,
           isDirectory    : IS_FILE,
           metadata,
-          mode           : R_OK | W_OK,
+          mode           : R_OK | W_OK | S_IFREG,
           mtime          : new Date(properties.lastModified),
           size           : +properties.contentLength,
           url            : this._blobService.getUrl(this.container, pathname)
@@ -480,7 +482,7 @@ class AzureBlobFS {
         if (entries.length && entries[0].name === pathname + this.options.blobDelimiter) {
           return {
             isDirectory: IS_DIRECTORY,
-            mode: R_OK | W_OK | X_OK,
+            mode: R_OK | W_OK | X_OK | S_IFDIR,
             mtime: new Date(0),
             size: 0
           };
@@ -493,7 +495,7 @@ class AzureBlobFS {
 
       return {
         isDirectory: IS_DIRECTORY,
-        mode: R_OK | W_OK | X_OK,
+        mode: R_OK | W_OK | X_OK | S_IFDIR,
         mtime: new Date(lastModified),
         size: 0
       };


### PR DESCRIPTION
Fixed issue #38 by encoding the type within the `mode` property. This will allow the "stat-mode" package to function properly and therefore will let ftpd work correctly. 

This is a quick and dirty fix as the constants for File and Directory are hardcoded within this change - they are exported by "fs" but were empty when I tried to use them. If someone has a better approach to get the values, I am open for suggestions :)